### PR TITLE
Update object field serialization ordering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,11 +78,9 @@ function serialize (value, type) {
 
   // serializes objects (including compound objects)
   if ((typeof type === 'object' || typeof type === 'function') && type.hasOwnProperty('fields')) {
-    let buffers = []
-    Object.keys(type.fields)
-      .sort()
-      .forEach(fieldName => {
-        buffers.push(serialize(value[fieldName], type.fields[fieldName]))
+    const buffers = type.fields
+      .map(([fieldName, fieldType]) => {
+        return serialize(value[fieldName], fieldType)
       })
 
     let totalByteLength = buffers.reduce((acc, v) => acc + v.byteLength, 0)
@@ -195,10 +193,9 @@ function deserialize (data, start, type) {
     let output = {}
     let position = start + int32ByteLength
 
-    Object.keys(type.fields)
-      .sort()
-      .forEach(fieldName => {
-        let fieldResult = deserialize(data, position, type.fields[fieldName])
+    type.fields
+      .forEach(([fieldName, fieldType]) => {
+        let fieldResult = deserialize(data, position, fieldType)
         position = fieldResult.offset
         output[fieldName] = fieldResult.deserializedData
       })

--- a/test/test_ssz_serialize.js
+++ b/test/test_ssz_serialize.js
@@ -6,6 +6,12 @@ const intByteLength = require('../src/intBytes').intByteLength;
 const ActiveState = require('./utils/activeState').ActiveState;
 const AttestationRecord = require('./utils/activeState').AttestationRecord;
 const serialize = require('../src').serialize;
+const testObjects = require('./utils/objects')
+
+const SimpleObject = testObjects.SimpleObject
+const OuterObject = testObjects.OuterObject
+const InnerObject = testObjects.InnerObject
+const ArrayObject = testObjects.ArrayObject
 
 describe('SimpleSerialize - serializes booleans', () => {
 
@@ -622,17 +628,17 @@ describe('SimpleSerialize - serializes objects', () => {
                 'zz3': boolValue
             },
             {
-                'fields':{
-                    'publicAddress': 'bytes20',
-                    'secret': 'bytes32',
-                    'age': 'int8',
-                    'distance': 'int16',
-                    'halfLife': 'int32',
-                    'file': 'bytes',
-                    'zz1': 'uint64',
-                    'zz2': 'int256',
-                    'zz3': 'bool'
-                }
+                'fields': [
+                    ['age', 'int8'],
+                    ['distance', 'int16'],
+                    ['file', 'bytes'],
+                    ['halfLife', 'int32'],
+                    ['publicAddress', 'bytes20'],
+                    ['secret', 'bytes32'],
+                    ['zz1', 'uint64'],
+                    ['zz2', 'int256'],
+                    ['zz3', 'bool'],
+                ]
             }
         );
         
@@ -765,5 +771,17 @@ describe('SimpleSerialize - serializes objects', () => {
 
         return offset;
     }
-
+    const testCases = [
+      [[new SimpleObject({b:0,a:0}), SimpleObject], "00000003000000"],
+      [[new SimpleObject({b:2,a:1}), SimpleObject], "00000003000201"],
+      [[new OuterObject({v:3,subV:new InnerObject({v:6})}), OuterObject], "0000000703000000020006"],
+      [[new ArrayObject({v: [new SimpleObject({b:2,a:1}), new SimpleObject({b:4,a:3})]}), ArrayObject], "000000120000000e0000000300020100000003000403"],
+      [[[new OuterObject({v:3, subV:new InnerObject({v:6})}), new OuterObject({v:5, subV:new InnerObject({v:7})})],[OuterObject]], "0000001600000007030000000200060000000705000000020007"],
+    ]
+    for (const [input, output] of testCases) {
+      const [value, type] = input
+      it(`serializes objects - ${type.name || typeof type}`, () => {
+        assert.equal(serialize(value, type).toString('hex'), output)
+      })
+    }
 });

--- a/test/utils/activeState.js
+++ b/test/utils/activeState.js
@@ -1,10 +1,10 @@
 class ActiveState {
     static get fields(){ 
-        return {
-            'pendingAttestations': [AttestationRecord],
-            'recentBlockHashes': ['bytes32']
+        return [
+            ['pendingAttestations', [AttestationRecord]],
+            ['recentBlockHashes', ['bytes32']]
 
-        }; 
+        ]; 
     }
 
     constructor(){
@@ -15,11 +15,11 @@ class ActiveState {
 
 class AttestationRecord {
     static get fields(){ 
-        return {
-            'slotId': 'int32',
-            'shardId': 'int32',
-            'attesterBitfield': 'bytes'
-        }
+        return [
+            ['attesterBitfield', 'bytes'],
+            ['shardId', 'int32'],
+            ['slotId', 'int32'],
+        ]
     }
 
     constructor(slotId, shardId, attesterBitfield) {

--- a/test/utils/objects.js
+++ b/test/utils/objects.js
@@ -1,0 +1,48 @@
+// Adapted from https://github.com/prysmaticlabs/prysm/blob/master/shared/ssz/encode_test.go#L296
+
+class SimpleObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+SimpleObject.fields = [
+  ['b', 'uint16'],
+  ['a', 'uint8'],
+]
+
+class InnerObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+InnerObject.fields = [
+  ['v', 'uint16'],
+]
+
+class OuterObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+OuterObject.fields = [
+  ['v', 'uint8'],
+  ['subV', InnerObject],
+]
+
+class ArrayObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+ArrayObject.fields = [
+  ['v', [SimpleObject]],
+]
+
+exports.SimpleObject = SimpleObject
+exports.InnerObject = InnerObject
+exports.OuterObject = OuterObject
+exports.ArrayObject = ArrayObject


### PR DESCRIPTION
Resolves #22 

Updates the data format of type.fields: use an Array of pairs, instead of an object.
eg:
```javascript
x.fields = {
  a: 'uint16',
  b: 'uint8',
  c: 'bytes',
}
```
is now:
```javascript
x.fields = [
  ['a', 'uint16'],
  ['b', 'uint8'],
  ['c', 'bytes'],
]
```

Also adds tests adopted from prysm, we pass! :tada: and have proof that we serialize/deserialize objects the same way as them.