### PR TITLE
Tree hash object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ function treeHash (value, type, recursive = false) {
     const elementType = type[0]
     output = merkleHash(value.map(v => treeHash(v, elementType, true)))
   } else if ((typeof type === 'object' || typeof type === 'function') && type.hasOwnProperty('fields')) {
-    output = hash(type.fields.map(f => treeHash(value[f], type[f], true)))
+    output = hash(Buffer.concat(type.fields.map(([fieldName, fieldType]) => treeHash(value[fieldName], fieldType, true))))
   }
   if (!output) {
     throw Error(`Unable to hash value ${value} of type ${type}`)

--- a/src/index.js
+++ b/src/index.js
@@ -78,11 +78,9 @@ function serialize (value, type) {
 
   // serializes objects (including compound objects)
   if ((typeof type === 'object' || typeof type === 'function') && type.hasOwnProperty('fields')) {
-    let buffers = []
-    Object.keys(type.fields)
-      .sort()
-      .forEach(fieldName => {
-        buffers.push(serialize(value[fieldName], type.fields[fieldName]))
+    const buffers = type.fields
+      .map(([fieldName, fieldType]) => {
+        return serialize(value[fieldName], fieldType)
       })
 
     let totalByteLength = buffers.reduce((acc, v) => acc + v.byteLength, 0)
@@ -195,10 +193,9 @@ function deserialize (data, start, type) {
     let output = {}
     let position = start + int32ByteLength
 
-    Object.keys(type.fields)
-      .sort()
-      .forEach(fieldName => {
-        let fieldResult = deserialize(data, position, type.fields[fieldName])
+    type.fields
+      .forEach(([fieldName, fieldType]) => {
+        let fieldResult = deserialize(data, position, fieldType)
         position = fieldResult.offset
         output[fieldName] = fieldResult.deserializedData
       })

--- a/test/test_ssz_serialize.js
+++ b/test/test_ssz_serialize.js
@@ -6,6 +6,12 @@ const intByteLength = require('../src/intBytes').intByteLength;
 const ActiveState = require('./utils/activeState').ActiveState;
 const AttestationRecord = require('./utils/activeState').AttestationRecord;
 const serialize = require('../src').serialize;
+const testObjects = require('./utils/objects')
+
+const SimpleObject = testObjects.SimpleObject
+const OuterObject = testObjects.OuterObject
+const InnerObject = testObjects.InnerObject
+const ArrayObject = testObjects.ArrayObject
 
 describe('SimpleSerialize - serializes booleans', () => {
 
@@ -622,17 +628,17 @@ describe('SimpleSerialize - serializes objects', () => {
                 'zz3': boolValue
             },
             {
-                'fields':{
-                    'publicAddress': 'bytes20',
-                    'secret': 'bytes32',
-                    'age': 'int8',
-                    'distance': 'int16',
-                    'halfLife': 'int32',
-                    'file': 'bytes',
-                    'zz1': 'uint64',
-                    'zz2': 'int256',
-                    'zz3': 'bool'
-                }
+                'fields': [
+                    ['age', 'int8'],
+                    ['distance', 'int16'],
+                    ['file', 'bytes'],
+                    ['halfLife', 'int32'],
+                    ['publicAddress', 'bytes20'],
+                    ['secret', 'bytes32'],
+                    ['zz1', 'uint64'],
+                    ['zz2', 'int256'],
+                    ['zz3', 'bool'],
+                ]
             }
         );
         
@@ -765,5 +771,17 @@ describe('SimpleSerialize - serializes objects', () => {
 
         return offset;
     }
-
+    const testCases = [
+      [[new SimpleObject({b:0,a:0}), SimpleObject], "00000003000000"],
+      [[new SimpleObject({b:2,a:1}), SimpleObject], "00000003000201"],
+      [[new OuterObject({v:3,subV:new InnerObject({v:6})}), OuterObject], "0000000703000000020006"],
+      [[new ArrayObject({v: [new SimpleObject({b:2,a:1}), new SimpleObject({b:4,a:3})]}), ArrayObject], "000000120000000e0000000300020100000003000403"],
+      [[[new OuterObject({v:3, subV:new InnerObject({v:6})}), new OuterObject({v:5, subV:new InnerObject({v:7})})],[OuterObject]], "0000001600000007030000000200060000000705000000020007"],
+    ]
+    for (const [input, output] of testCases) {
+      const [value, type] = input
+      it(`serializes objects - ${type.name || typeof type}`, () => {
+        assert.equal(serialize(value, type).toString('hex'), output)
+      })
+    }
 });

--- a/test/test_ssz_treehash.js
+++ b/test/test_ssz_treehash.js
@@ -1,8 +1,16 @@
 const assert = require('chai').assert
+const BN = require('bn.js')
 
 const hexToBytes = require('./utils/hexToBytes').hexToBytes
 const treeHash = require('../src').treeHash
 const merkleHash = require('../src').merkleHash
+const testObjects = require('./utils/objects')
+
+const SimpleObject = testObjects.SimpleObject
+const OuterObject = testObjects.OuterObject
+const InnerObject = testObjects.InnerObject
+const ArrayObject = testObjects.ArrayObject
+
 
 describe('SimpleSerialize - tree hashes', () => {
   const testCases = [
@@ -35,8 +43,7 @@ describe('SimpleSerialize - tree hashes', () => {
     [[255, 'uint64'], "00000000000000ff000000000000000000000000000000000000000000000000"],
     [[65535, 'uint64'], "000000000000ffff000000000000000000000000000000000000000000000000"],
     [[4294967295, 'uint64'], "00000000ffffffff000000000000000000000000000000000000000000000000"],
-    // TODO: support bigints
-    // [[18446744073709551615, 'uint64'], "ffffffffffffffff000000000000000000000000000000000000000000000000"],
+    [[new BN('18446744073709551615'), 'uint64'], "ffffffffffffffff000000000000000000000000000000000000000000000000"],
     // bytes
     [[Buffer.alloc(0), 'bytes'],'e8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c'],
     [[Buffer.from([1]), 'bytes'], 'a01f051be047843977f523e7944513ebbedd5568cc9911c955850f3cccc6979f'],
@@ -46,10 +53,25 @@ describe('SimpleSerialize - tree hashes', () => {
     [[[1], ['uint16']], '75848bb7f08d2e009e76fdad5a1c6129e48df34d81245405f9c43b53d204dfaf'],
     [[[1, 2], ['uint16']], '02a9991b320fd848fdff2e069ff4a6e2b2a593fa13c32201ec89d5272332908d'],
     [[[[1,2,3,4],[5,6,7,8]], [['uint16']]], 'd779c77e9e3fe29311097a0d62aa55077c2accc2ce89d6c3024877ca73222bb3'],
+    // object
+    [[new SimpleObject({b:0,a:0}), SimpleObject], '99ff0d9125e1fc9531a11262e15aeb2c60509a078c4cc4c64cefdfb06ff68647'],
+    [[new SimpleObject({b:2,a:1}), SimpleObject], 'd841aa2ce38fda992d162d973ebd62cf0c74522f8feb294c48a03d4db0a6b78c'],
+    [[new OuterObject({v:3,subV: new InnerObject({v:6})}), OuterObject], '22e310a4b644fbcf2a8f90ac1a5311ed9070e6c9e68a2fe58082bbf78c0d030e'],
+    [[new ArrayObject({v: [new SimpleObject({b:2,a:1}), new SimpleObject({b:4,a:3})]}), ArrayObject], 'c338a2c69762d374cf6453ddf9b1d685d75243cf59b1fdd9a4df4db623e80512'],
+    [[[new OuterObject({v:3,subV: new InnerObject({v:6})}), new OuterObject({v:5,subV: new InnerObject({v:7})})], [OuterObject]], 'd568df03934c0ee51f49aabe81f20844d2f44159c389411bbc0c6008d5d85395'],
   ]
+  const stringifyType = type => {
+    if (typeof type === 'string') {
+      return type
+    } else if (Array.isArray(type)) {
+      return `[${stringifyType(type[0])}]`
+    } else if (typeof type === 'function') {
+      return type.name
+    } else return ''
+  }
   for (const [input, output] of testCases) {
     const [value, type] = input
-    it(`successfully tree hashes ${JSON.stringify(type)}`, () => {
+    it(`successfully tree hashes ${stringifyType(type)}`, () => {
       assert.equal(treeHash(value, type).toString('hex'), output)
     })
   }

--- a/test/utils/activeState.js
+++ b/test/utils/activeState.js
@@ -1,10 +1,10 @@
 class ActiveState {
     static get fields(){ 
-        return {
-            'pendingAttestations': [AttestationRecord],
-            'recentBlockHashes': ['bytes32']
+        return [
+            ['pendingAttestations', [AttestationRecord]],
+            ['recentBlockHashes', ['bytes32']]
 
-        }; 
+        ]; 
     }
 
     constructor(){
@@ -15,11 +15,11 @@ class ActiveState {
 
 class AttestationRecord {
     static get fields(){ 
-        return {
-            'slotId': 'int32',
-            'shardId': 'int32',
-            'attesterBitfield': 'bytes'
-        }
+        return [
+            ['attesterBitfield', 'bytes'],
+            ['shardId', 'int32'],
+            ['slotId', 'int32'],
+        ]
     }
 
     constructor(slotId, shardId, attesterBitfield) {

--- a/test/utils/objects.js
+++ b/test/utils/objects.js
@@ -1,0 +1,48 @@
+// Adapted from https://github.com/prysmaticlabs/prysm/blob/master/shared/ssz/encode_test.go#L296
+
+class SimpleObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+SimpleObject.fields = [
+  ['b', 'uint16'],
+  ['a', 'uint8'],
+]
+
+class InnerObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+InnerObject.fields = [
+  ['v', 'uint16'],
+]
+
+class OuterObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+OuterObject.fields = [
+  ['v', 'uint8'],
+  ['subV', InnerObject],
+]
+
+class ArrayObject {
+  constructor(opts) {
+    Object.keys(opts)
+      .forEach(key => this[key] = opts[key])
+  }
+}
+ArrayObject.fields = [
+  ['v', [SimpleObject]],
+]
+
+exports.SimpleObject = SimpleObject
+exports.InnerObject = InnerObject
+exports.OuterObject = OuterObject
+exports.ArrayObject = ArrayObject


### PR DESCRIPTION
Relies on test infrastructure in #28 (once we merge it, this diff will be smaller and make sense)

Fixes object tree hashing based on #28 
Adds tests adapted from prysm
Reenables bignum tree hash test case