### PR TITLE
Allow browser Buffer

### DIFF
--- a/src/intBytes.js
+++ b/src/intBytes.js
@@ -18,7 +18,7 @@ function readIntBytes (type) {
 function writeIntBytes (type) {
   let intSize = parseInt(type.match(/\d+/g))
   let byteSize = intSize / 8
-  return (buffer, value) => { new BN(value).toTwos(intSize).toBuffer('le', byteSize).copy(buffer) }
+  return (buffer, value) => { new BN(value).toTwos(intSize).toArrayLike(Buffer, 'le', byteSize).copy(buffer) }
 }
 
 exports.intByteLength = intByteLength


### PR DESCRIPTION
After doing some digging, it appears that, contrary to the exact language in #33, the standard way of dealing with Buffer (allowing it to work in the browser) is to let the 'last step' of the build process do the polyfill. This makes more sense than I originally thought, rationale below.

What that means, is that most libraries relying on Buffer (eg: our dependency @polkadot/util included) use Buffer assuming its availability, and then later consumers of these libraries (for web) would bundle in a polyfill as a step of the bundling process.

The reason for this approach is that it simplifies larger projects from unintended hackiness surrounding Buffer, specifically when running on node.
Imagine library B uses library A. If library A hardcodes the feross/buffer dependency, library B, (and even all consumers of library B), are bound to use that implementation, which is really meant as a browser polyfill.

It makes more sense for the bundler, which is already collating the tree of a project's dependencies, to have more information about the run-time environment, and make the appropriate choice at the end.
That way, all references to Buffer can either be linked at once, or all of them left alone.

Regarding this specific PR, according to the bn.js [README](https://github.com/indutny/bn.js#utilities), we need to use `toArrayLike`. This is because `toBuffer` will not be created for browser builds. (Due to some fancy use of [this feature](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module), more info in [this bn.js PR](https://github.com/indutny/bn.js/commit/7e6f9d2959117a71ca9ac1a46de4b9cb5bf17b76))