### PR TITLE
Simplify object tests

### DIFF
--- a/test/test_ssz_deserialize.js
+++ b/test/test_ssz_deserialize.js
@@ -488,11 +488,11 @@ describe('SimpleSerialize - deserialize objects', () => {
     });
 
     const testCases = [
-      [["30000000000000", SimpleObject], new SimpleObject({b:0,a:0})],
-      [["03000000020001", SimpleObject], new SimpleObject({b:2,a:1})],
-      [["0700000003020000000600", OuterObject], new OuterObject({v:3, subV: new InnerObject({v:6})})],
-      [["120000000E0000000300000002000103000000040003", ArrayObject], new ArrayObject({v: [new SimpleObject({b:2,a:1}), new SimpleObject({b:4,a:3})]})],
-      [["1600000007000000030200000006000700000005020000020700", [OuterObject]], [new OuterObject({v:3, subV: new InnerObject({v:6})}), new OuterObject({v:5, subV: new InnerObject({v:7})})]],
+      [["30000000000000", SimpleObject], {b:0,a:0}],
+      [["03000000020001", SimpleObject], {b:2,a:1}],
+      [["0700000003020000000600", OuterObject], {v:3, subV: {v:6}}],
+      [["120000000E0000000300000002000103000000040003", ArrayObject], {v: [{b:2,a:1}, {b:4,a:3}]}],
+      [["1600000007000000030200000006000700000005020000020700", [OuterObject]], [{v:3, subV: {v:6}}, {v:5, subV: {v:7}}]],
     ];
 
     // like a deepEqual,but reliant on type, instead of inspection of ownProperties

--- a/test/test_ssz_serialize.js
+++ b/test/test_ssz_serialize.js
@@ -770,11 +770,11 @@ describe('SimpleSerialize - serializes objects', () => {
         return offset;
     }
     const testCases = [
-      [[new SimpleObject({b:0,a:0}), SimpleObject], "03000000000000"],
-      [[new SimpleObject({b:2,a:1}), SimpleObject], "03000000020001"],
-      [[new OuterObject({v:3,subV:new InnerObject({v:6})}), OuterObject], "0700000003020000000600"],
-      [[new ArrayObject({v: [new SimpleObject({b:2,a:1}), new SimpleObject({b:4,a:3})]}), ArrayObject], "120000000e0000000300000002000103000000040003"],
-      [[[new OuterObject({v:3, subV:new InnerObject({v:6})}), new OuterObject({v:5, subV:new InnerObject({v:7})})],[OuterObject]], "1600000007000000030200000006000700000005020000000700"],
+      [[{b:0,a:0}, SimpleObject], "03000000000000"],
+      [[{b:2,a:1}, SimpleObject], "03000000020001"],
+      [[{v:3, subV:{v:6}}, OuterObject], "0700000003020000000600"],
+      [[{v: [{b:2,a:1}, {b:4,a:3}]}, ArrayObject], "120000000e0000000300000002000103000000040003"],
+      [[[{v:3, subV:{v:6}}, {v:5, subV:{v:7}}], [OuterObject]], "1600000007000000030200000006000700000005020000000700"],
     ];
 
     for (const [input, output] of testCases) {

--- a/test/test_ssz_treehash.js
+++ b/test/test_ssz_treehash.js
@@ -57,11 +57,11 @@ describe('SimpleSerialize - tree hashes', () => {
     [[[1, 2], ['uint16']], 'a9b7d66d80f70c6da7060c3dedb01e6ed6cea251a3247093cbf27a439ecb0bea'],
     [[[[1,2,3,4],[5,6,7,8]], [['uint16']]], '1a400eb17c755e4445c2c57dd2d3a0200a290c56cd68957906dd7bfe04493b10'],
     // object
-    [[new SimpleObject({b:0,a:0}), SimpleObject], '99ff0d9125e1fc9531a11262e15aeb2c60509a078c4cc4c64cefdfb06ff68647'],
-    [[new SimpleObject({b:2,a:1}), SimpleObject], 'd2b49b00c76582823e30b56fe608ff030ef7b6bd7dcc16b8994c9d74860a7e1c'],
-    [[new OuterObject({v:3,subV: new InnerObject({v:6})}), OuterObject], 'bb2f30386c55445381eee7a33c3794227b8c8e4be4caa54506901a4ddfe79ee2'],
-    [[new ArrayObject({v: [new SimpleObject({b:2,a:1}), new SimpleObject({b:4,a:3})]}), ArrayObject], 'f3032dce4b4218187e34aa8b6ef87a3fabe1f8d734ce92796642dc6b2911277c'],
-    [[[new OuterObject({v:3,subV: new InnerObject({v:6})}), new OuterObject({v:5,subV: new InnerObject({v:7})})], [OuterObject]], 'de43bc05aa6b011121f9590c10de1734291a595798c84a0e3edd1cc1e6710908'],
+    [[{b:0,a:0}, SimpleObject], '99ff0d9125e1fc9531a11262e15aeb2c60509a078c4cc4c64cefdfb06ff68647'],
+    [[{b:2,a:1}, SimpleObject], 'd2b49b00c76582823e30b56fe608ff030ef7b6bd7dcc16b8994c9d74860a7e1c'],
+    [[{v:3,subV: {v:6}}, OuterObject], 'bb2f30386c55445381eee7a33c3794227b8c8e4be4caa54506901a4ddfe79ee2'],
+    [[{v: [{b:2,a:1}, {b:4,a:3}]}, ArrayObject], 'f3032dce4b4218187e34aa8b6ef87a3fabe1f8d734ce92796642dc6b2911277c'],
+    [[[{v:3, subV:{v:6}}, {v:5, subV:{v:7}}], [OuterObject]], 'de43bc05aa6b011121f9590c10de1734291a595798c84a0e3edd1cc1e6710908'],
   ];
 
   const stringifyType = type => {

--- a/test/utils/objects.js
+++ b/test/utils/objects.js
@@ -1,46 +1,30 @@
 // Adapted from https://github.com/prysmaticlabs/prysm/blob/master/shared/ssz/encode_test.go#L296
 
-class SimpleObject {
-  constructor(opts) {
-    Object.keys(opts)
-      .forEach(key => this[key] = opts[key])
-  }
+const SimpleObject = {
+  fields: [
+    ['b', 'uint16'],
+    ['a', 'uint8'],
+  ],
 }
-SimpleObject.fields = [
-  ['b', 'uint16'],
-  ['a', 'uint8'],
-]
 
-class InnerObject {
-  constructor(opts) {
-    Object.keys(opts)
-      .forEach(key => this[key] = opts[key])
-  }
+const InnerObject = {
+  fields: [
+    ['v', 'uint16'],
+  ],
 }
-InnerObject.fields = [
-  ['v', 'uint16'],
-]
 
-class OuterObject {
-  constructor(opts) {
-    Object.keys(opts)
-      .forEach(key => this[key] = opts[key])
-  }
+const OuterObject = {
+  fields: [
+    ['v', 'uint8'],
+    ['subV', InnerObject],
+  ],
 }
-OuterObject.fields = [
-  ['v', 'uint8'],
-  ['subV', InnerObject],
-]
 
-class ArrayObject {
-  constructor(opts) {
-    Object.keys(opts)
-      .forEach(key => this[key] = opts[key])
-  }
+const ArrayObject = {
+  fields: [
+    ['v', [SimpleObject]],
+  ],
 }
-ArrayObject.fields = [
-  ['v', [SimpleObject]],
-]
 
 exports.SimpleObject = SimpleObject
 exports.InnerObject = InnerObject


### PR DESCRIPTION
The object-oriented style makes the tests more complicated than necessary.
This converges test cases to a form more similar to how downstream consumers are likely to use the library (See https://github.com/ChainSafeSystems/lodestar/pull/80)
- Convert object test cases to simple object literals
- Convert object 'types' to objects

It may be good to add more test cases in the future showing multiple different styles of use, but it feels more pertinent to simplify and align for now.