### PR TITLE
[ETHDenver] Fix merkleisation bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,11 +307,21 @@ function merkleHash (list) {
     chunkz = list
   }
 
-  // Tree-hash
-  while (chunkz.length > 1) {
-    if (chunkz.length % 2 === 1) {
-      chunkz.push(Buffer.alloc(SSZ_CHUNK_SIZE))
+  const bitLength = (x) => {
+    let numBits = 0
+    while (x !== 0) {
+      x = x >> 1
+      numBits++
     }
+    return numBits
+  }
+  const nextPowerOf2 = (x) => x === 0 ? 1 : Math.pow(2, bitLength(x - 1))
+  // Add zeroed chunks as leaf nodes to create full binary tree
+  chunkz = chunkz.concat(
+    Array.from({ length: nextPowerOf2(chunkz.length) - chunkz.length },
+      () => Buffer.alloc(SSZ_CHUNK_SIZE)))
+  // Merkleise
+  while (chunkz.length > 1) {
     const chunkz2 = []
     for (let i = 0; i < chunkz.length; i += 2) {
       chunkz2.push(hash(Buffer.concat([chunkz[i], chunkz[i + 1]])))


### PR DESCRIPTION
See https://github.com/ethereum/eth2.0-specs/pull/602

Previously, we were adding zeroed chunks at intermediate levels as needed to fill in the merkle tree.
Now, we add zeroed chunks up-front as leaf nodes.

Most LOC added here are helper functions to determine the # of zeroed chunks to add.